### PR TITLE
fix: resolve #1 — Bug: int conversion fails on non-numeric input

### DIFF
--- a/src/converter.py
+++ b/src/converter.py
@@ -1,5 +1,8 @@
 def convert_value(x):
-    return int("abc")
+    try:
+        return int(x)
+    except ValueError as exc:
+        raise ValueError(f"Invalid integer input: {x!r}") from exc
 
 
 if __name__ == "__main__":

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,3 +1,5 @@
+import pytest
+
 from src.app import process_data
 
 
@@ -5,8 +7,14 @@ def test_process_data():
     assert process_data([1, 2, 3]) == [2, 4, 6]
 
 
-def test_convert_value_fails():
-    """This test deliberately fails to give CI Fixer something to fix."""
+def test_convert_value_numeric_string():
     from src.converter import convert_value
-    result = convert_value("hello")
-    assert result == 42
+
+    assert convert_value("42") == 42
+
+
+def test_convert_value_non_numeric_raises_descriptive_error():
+    from src.converter import convert_value
+
+    with pytest.raises(ValueError, match="Invalid integer input"):
+        convert_value("hello")


### PR DESCRIPTION
Fixes #1

## What changed
1) Update `src/converter.py:convert_value()` to convert the provided argument (`x`) instead of the hardcoded string, and wrap conversion in a `try/except ValueError` path.
2) Implement the chosen graceful behavior from the issue expectation (prefer raising a descriptive `ValueError`, or return a documented default if project conventions require that).
3) Add or update tests in `tests/test_basic.py` to cover: numeric string input succeeds, non-numeric input is handled gracefully, and behavior matches the selected contract.
4) Run the test suite and verify no regressions in existing conversion-related behavior.
5) If needed, adjust calling code/docs to reflect the finalized error/default-value behavior for invalid input.

---
*Automated fix by Issue Fixer*