### PR TITLE
fix: resolve #8 — [Scan] Hardcoded secrets and database URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
 SECRET_KEY=changeme
 DATABASE_PASSWORD=changeme
 API_TOKEN=changeme
+AWS_ACCESS_KEY_ID=changeme
+AWS_SECRET_ACCESS_KEY=changeme
+DATABASE_URL=postgresql://user:password@localhost:5432/myapp

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # automations-test-target
 
 Test target repository for the automations app. Contains intentional code issues for automation testing.
+
+## Required environment variables
+
+Set the following environment variables before running code that uses `src/utils.py`:
+- `AWS_ACCESS_KEY_ID`
+- `AWS_SECRET_ACCESS_KEY`
+- `DATABASE_URL`

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,12 +1,22 @@
-AWS_ACCESS_KEY = "AKIAIOSFODNN7EXAMPLE"
-AWS_SECRET_KEY = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+import os
 
-DATABASE_URL = "postgresql://admin:supersecret@prod-db.internal:5432/myapp"
+AWS_ACCESS_KEY_ID = os.getenv("AWS_ACCESS_KEY_ID")
+AWS_SECRET_ACCESS_KEY = os.getenv("AWS_SECRET_ACCESS_KEY")
+DATABASE_URL = os.getenv("DATABASE_URL")
+
+
+def _require_env(name, value):
+    if not value:
+        raise RuntimeError(f"Missing required environment variable: {name}")
+    return value
 
 
 def get_connection_string():
-    return DATABASE_URL
+    return _require_env("DATABASE_URL", DATABASE_URL)
 
 
 def get_aws_credentials():
-    return AWS_ACCESS_KEY, AWS_SECRET_KEY
+    return (
+        _require_env("AWS_ACCESS_KEY_ID", AWS_ACCESS_KEY_ID),
+        _require_env("AWS_SECRET_ACCESS_KEY", AWS_SECRET_ACCESS_KEY),
+    )


### PR DESCRIPTION
Fixes #8

## What changed
1) Open `src/utils.py` and identify the hardcoded AWS access key, AWS secret key, and database URL constants flagged by the scanner. 2) Replace hardcoded secret values with environment-variable lookups (for example via `os.getenv`), using clear variable names such as `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `DATABASE_URL`. 3) Add explicit validation so the module fails fast with a clear error message if required environment variables are missing, instead of silently using insecure defaults. 4) Refactor any code paths that directly consume the old constants to use the new config-loading variables/functions so behavior remains consistent. 5) Update project configuration docs/examples (e.g., `.env.example` or README config section) to document required environment variables without including real credentials. 6) Run tests/lint (or a targeted smoke check) to verify no regressions and confirm scanner warning is resolved.

---
*Automated fix by Issue Fixer*