### PR TITLE
fix: resolve #1 — Bug: int conversion fails on non-numeric input

### DIFF
--- a/src/converter.py
+++ b/src/converter.py
@@ -1,5 +1,8 @@
 def convert_value(x):
-    return int("abc")
+    try:
+        return int(x)
+    except (TypeError, ValueError):
+        raise ValueError("convert_value expects a numeric value")
 
 
 if __name__ == "__main__":

--- a/src/parser.py
+++ b/src/parser.py
@@ -1,3 +1,3 @@
 def parse_config(raw):
-    value = l
+    value = raw
     return value

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,3 +1,5 @@
+import pytest
+
 from src.app import process_data
 
 
@@ -5,8 +7,21 @@ def test_process_data():
     assert process_data([1, 2, 3]) == [2, 4, 6]
 
 
-def test_convert_value_fails():
-    """This test deliberately fails to give CI Fixer something to fix."""
+def test_convert_value_valid_numeric_string():
     from src.converter import convert_value
-    result = convert_value("hello")
-    assert result == 42
+
+    assert convert_value("42") == 42
+
+
+def test_convert_value_invalid_string_raises_value_error():
+    from src.converter import convert_value
+
+    with pytest.raises(ValueError, match="expects a numeric value"):
+        convert_value("hello")
+
+
+def test_convert_value_none_raises_value_error():
+    from src.converter import convert_value
+
+    with pytest.raises(ValueError, match="expects a numeric value"):
+        convert_value(None)


### PR DESCRIPTION
Fixes #1

## What changed
1) Update `src/converter.py:convert_value()` to convert the provided argument (`x`) instead of the hardcoded string `"abc"`.
2) Add graceful handling for non-numeric input by catching `ValueError` (and likely `TypeError`) and choosing one explicit behavior aligned with the issue expectation (either return a default value such as 0, or raise a clearer descriptive error).
3) Keep behavior for valid numeric input unchanged (e.g., `"42" -> 42`).
4) Update tests in `tests/test_basic.py` to replace the intentionally failing expectation with assertions that reflect the chosen non-numeric behavior.
5) Add/adjust test cases for: valid numeric string, invalid string input, and optional edge case like `None`.
6) Run the test suite to verify the fix and prevent regression.

---
*Automated fix by Issue Fixer*